### PR TITLE
Sync RAW fallback photos with TSV

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,22 +154,22 @@ var RAW = `id\tparentId\tname\ttitle\tdepartment\tlocation\tphoto\tboardVertex\t
 11\t1\tMihaela Gana\tManager Subcontractori\t\t\t\t\t\tProductive\t\tmihaela.gana@dumagas.com\t0729209280\t\t\t
 L1_2A\t2\tJURIDIC\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t1
 L1_2B\t2\tIT\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t2
-L2_2B1\tL1_2B\tGolea Laurentiu\tExternal IT Software\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
+L2_2B1\tL1_2B\tGolea Laurentiu\tExternal IT Software\t\t\tassets/L2_2B1.jpg\t\t\tAdministrative\t\t\t\t\t\t
 L2_2B2\tL1_2B\tClaudiu Radulescu\tAsistent IT Hardware\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
-L1_2A1\tL1_2A\tVoica Catalin\tJurist\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
+L1_2A1\tL1_2A\tVoica Catalin\tJurist\t\t\tassets/L1_2A1.jpg\t\t\tAdministrative\t\t\t\t\t\t
 L1_3A\t3\tADMINISTRATIV\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t1
 L1_3B\t3\tFINANCIAR CONTABIL\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t2
-L1_3A1\tL1_3A\tRadu Silvia\tServicii Curatenie\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
-L1_3A2\tL1_3A\tMaruntelu Camelia-Paula\tBucatareasa\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
-L1_3A3\tL1_3A\tBegu Marian\tInginer Electroenergetic\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
-L1_3B1\tL1_3B\tDinca Ioana-Diana\tOperator Facturare\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
-L1_3B2\tL1_3B\tSirbi Ileana\tOperator Facturare\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
+L1_3A1\tL1_3A\tRadu Silvia\tServicii Curatenie\t\t\tassets/L1_3A1.jpg\t\t\tAdministrative\t\t\t\t\t\t
+L1_3A2\tL1_3A\tMaruntelu Camelia-Paula\tBucatareasa\t\t\tassets/L1_3A2.jpg\t\t\tAdministrative\t\t\t\t\t\t
+L1_3A3\tL1_3A\tBegu Marian\tInginer Electroenergetic\t\t\tassets/L1_3A3.jpg\t\t\tAdministrative\t\t\t\t\t\t
+L1_3B1\tL1_3B\tDinca Ioana-Diana\tOperator Facturare\t\t\tassets/L1_3B1.jpg\t\t\tAdministrative\t\t\t\t\t\t
+L1_3B2\tL1_3B\tSirbi Ileana\tOperator Facturare\t\t\tassets/L1_3B2.jpg\t\t\tAdministrative\t\t\t\t\t\t
 L1_3B3\tL1_3B\tVlaescu Liliana-Nicoleta\tOperator Facturare\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
 L1_3B4\tL1_3B\tVelica Aurelia\tEconomist\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
 L1_3B5\tL1_3B\tLavinia Bogdan\tEconomist\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
 L1_4A\t4\tHR, PEOPLE & CULTURE\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t1
 L1_5A\t5\tSERVICE\t\t\t\t\t\tAdministrative\t\t\t\t\tlayer\t1
-L1_5A1\tL1_5A\tNovac Cristi\tTeam Lead\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
+L1_5A1\tL1_5A\tNovac Cristi\tTeam Lead\t\t\tassets/L1_5A1.jpg\t\t\tAdministrative\t\t\t\t\t\t
 L1_5A1b\tL1_5A1\tBunaiasu Constantin\tMecanic\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
 L1_5A1c\tL1_5A1\tMarinescu Nicolae-Madalin\tMecanic\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
 L1_5A1d\tL1_5A1\tMaruntelu Marian\tMecanic\t\t\t\t\t\tAdministrative\t\t\t\t\t\t
@@ -183,34 +183,34 @@ L1_6A1d\tL1_6A1\tDinut Gheorghe\tPicker\t\t\t\t\t\tProductive\t\t\t\t\t\t
 L1_6A1e\tL1_6A1\tZiane Ayoub\tManipulant\t\t\t\t\t\tProductive\t\t\t\t\t\t
 L1_7A\t7\tTRANSPORT SPECIALIZAT Auto-Transportoare, High & Heavy, Air Liquide\t\t\t\t\t\tProductive\t\t\t\t\tlayer\t1
 L1_7A1\tL1_7A\tManescu Alina\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_7A2\tL1_7A\tChilom Victor\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_7A3\tL1_7A\tCombei Ovidiu\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_7A2\tL1_7A\tChilom Victor\tTransport Manager\t\t\tassets/L1_7A2.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_7A3\tL1_7A\tCombei Ovidiu\tTransport Manager\t\t\tassets/L1_7A3.jpg\t\t\tProductive\t\t\t\t\t\t
 L1_7A4\tL1_7A\tFloricel Adrian\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
 L1_8A\t8\tINTERNATIONAL & ITALIA\t\t\t\t\t\tProductive\t\t\t\t\tlayer\t1
-L1_8A1\tL1_8A\tAndrei Delibasa\tTeam Lead Traffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A1a\tL1_8A1\tCatalina Avram\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A1b\tL1_8A1\tDaniela Iordache\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A1c\tL1_8A1\tCristian Grigore\tKey Account Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A1d\tL1_8A1\tAndrei Nicolae\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_8A1\tL1_8A\tAndrei Delibasa\tTeam Lead Traffic Manager\t\t\tassets/L1_8A1.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A1a\tL1_8A1\tCatalina Avram\tTraffic Manager\t\t\tassets/L1_8A1a.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A1b\tL1_8A1\tDaniela Iordache\tTraffic Manager\t\t\tassets/L1_8A1b.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A1c\tL1_8A1\tCristian Grigore\tKey Account Manager\t\t\tassets/L1_8A1c.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A1d\tL1_8A1\tAndrei Nicolae\tTransport Manager\t\t\tassets/L1_8A1d.jpg\t\t\tProductive\t\t\t\t\t\t
 L1_8A2\tL1_8A\tMirablea Pauna\tTeam Lead Transport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A2a\tL1_8A2\tEleonora Pita\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A2b\tL1_8A2\tDanut Preda\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A2c\tL1_8A2\tAdrian Dina\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_8A2d\tL1_8A2\tEugen Calusaru\tDrivers Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_8A2a\tL1_8A2\tEleonora Pita\tTraffic Manager\t\t\tassets/L1_8A2a.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A2b\tL1_8A2\tDanut Preda\tTransport Manager\t\t\tassets/L1_8A2b.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A2c\tL1_8A2\tAdrian Dina\tTransport Manager\t\t\tassets/L1_8A2c.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_8A2d\tL1_8A2\tEugen Calusaru\tDrivers Manager\t\t\tassets/L1_8A2d.jpg\t\t\tProductive\t\t\t\t\t\t
 L1_9A\t9\tDOMESTIC ROMANIA\t\t\t\t\t\tProductive\t\t\t\t\tlayer\t1
-L1_9A1\tL1_9A\tVasilescu Cristina\tTraffic Manager\t\tTurda\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A2\tL1_9A\tBerdut Alin\tTeam Lead Transport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A2a\tL1_9A2\tBaluta Viorica\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A2b\tL1_9A2\tBorcan Ciprian\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A2c\tL1_9A2\tBuliga Denisa\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A2d\tL1_9A2\tCiurca Gabriel\tTransport Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_9A1\tL1_9A\tVasilescu Cristina\tTraffic Manager\t\tTurda\tassets/L1_9A1.jpg\t\t\t\tProductive\t\t\t\t\t\t
+L1_9A2\tL1_9A\tBerdut Alin\tTeam Lead Transport Manager\t\t\tassets/L1_9A2.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_9A2a\tL1_9A2\tBaluta Viorica\tTraffic Manager\t\t\tassets/L1_9A2a.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_9A2b\tL1_9A2\tBorcan Ciprian\tTraffic Manager\t\t\tassets/L1_9A2b.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_9A2c\tL1_9A2\tBuliga Denisa\tTraffic Manager\t\t\tassets/L1_9A2c.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_9A2d\tL1_9A2\tCiurca Gabriel\tTransport Manager\t\t\tassets/L1_9A2d.jpg\t\t\tProductive\t\t\t\t\t\t
 L1_9A2e\tL1_9A2\tDelica Alina\tTraffic Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A1a\tL1_9A1\tMocan Alexandra\tTransport Manager\t\tTurda\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_9A1b\tL1_9A1\tPasc Madalina\tTransport Manager\t\tTurda\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_9A1a\tL1_9A1\tMocan Alexandra\tTransport Manager\t\tTurda\tassets/L1_9A1a.jpg\t\t\t\tProductive\t\t\t\t\t\t
+L1_9A1b\tL1_9A1\tPasc Madalina\tTransport Manager\t\tTurda\tassets/L1_9A1b.jpg\t\t\t\tProductive\t\t\t\t\t\t
 L1_11A\t11\tFLOTA SUBCONTRACTORI\t\t\t\t\t\tProductive\t\t\t\t\tlayer\t1
 L1_10A\t10\tDOMESTIC GERMANIA\t\t\t\t\t\tProductive\t\t\t\t\tlayer\t1
-L1_10A1\tL1_10A\tLaura Puica\tTransport Manager cu Rol Administrativ\t\t\t\t\t\tProductive\t\t\t\t\t\t
-L1_10A2\tL1_10A\tLavinel Cruceru\tTransport Manager cu Rol Tehnic\t\t\t\t\t\tProductive\t\t\t\t\t\t
+L1_10A1\tL1_10A\tLaura Puica\tTransport Manager cu Rol Administrativ\t\t\tassets/L1_10A1.jpg\t\t\tProductive\t\t\t\t\t\t
+L1_10A2\tL1_10A\tLavinel Cruceru\tTransport Manager cu Rol Tehnic\t\t\tassets/L1_10A2.jpg\t\t\tProductive\t\t\t\t\t\t
 L1_10A3\tL1_10A\tEugen Calusaru\tDriver's Manager\t\t\t\t\t\tProductive\t\t\t\t\t\t
 L1_10A2a\tL1_10A2\tBogdan Goiceanu\tDispecerat / Transport Management\t\t\t\t\t\tProductive\t\t\t\t\t\t
 L1_10A2b\tL1_10A2\tAlexandru Culcescu\tDispecerat / Transport Management\t\t\t\t\t\tProductive\t\t\t\t\t\t


### PR DESCRIPTION
## Summary
- update the inline RAW fallback dataset so each entry with a portrait in data/orgchart.tsv references the same photo asset
- keep the fallback data aligned with the external TSV for offline usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccfc795a288320b5c5d0d229109f69